### PR TITLE
feat: add a random 5 to 15 second dealy in create server

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/zolamk/terraform-provider-webdock/api"
@@ -16,11 +18,13 @@ type Config struct {
 
 type CombinedConfig struct {
 	api.ClientInterface
+	Logger *slog.Logger
 }
 
 func NewCombinedConfig(config *Config, client api.ClientInterface) *CombinedConfig {
 	return &CombinedConfig{
 		client,
+		slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	}
 }
 
@@ -39,5 +43,6 @@ func (c *Config) Client() (*CombinedConfig, diag.Diagnostics) {
 
 	return &CombinedConfig{
 		webdockClient,
+		slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	}, nil
 }

--- a/webdock/resource/server.go
+++ b/webdock/resource/server.go
@@ -3,7 +3,9 @@ package resource
 import (
 	"context"
 	"errors"
+	"math/rand"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -11,6 +13,11 @@ import (
 	"github.com/zolamk/terraform-provider-webdock/config"
 	"github.com/zolamk/terraform-provider-webdock/webdock/schemas"
 	"github.com/zolamk/terraform-provider-webdock/webdock/utils"
+)
+
+const (
+	minSleep = 5
+	maxSleep = 15
 )
 
 func Server() *schema.Resource {
@@ -26,6 +33,12 @@ func Server() *schema.Resource {
 
 func createServer(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.CombinedConfig)
+
+	delay := time.Second * time.Duration((rand.Intn(maxSleep-minSleep+1) + minSleep))
+
+	client.Logger.With("delay", delay).Info("sleeping to avoid concurrency issues")
+
+	time.Sleep(delay)
 
 	opts := api.CreateServerRequestBody{
 		Name:           d.Get("name").(string),


### PR DESCRIPTION
The webdock api has a problem when servers are created at the same instant, this change adds a random 5 to 15 second delay so that api calls are spread apart.