### PR TITLE
feat: make server creation delay predictable

### DIFF
--- a/webdock/resource/server.go
+++ b/webdock/resource/server.go
@@ -3,7 +3,6 @@ package resource
 import (
 	"context"
 	"errors"
-	"math/rand"
 	"strings"
 	"time"
 
@@ -13,11 +12,6 @@ import (
 	"github.com/zolamk/terraform-provider-webdock/config"
 	"github.com/zolamk/terraform-provider-webdock/webdock/schemas"
 	"github.com/zolamk/terraform-provider-webdock/webdock/utils"
-)
-
-const (
-	minSleep = 5
-	maxSleep = 15
 )
 
 func Server() *schema.Resource {
@@ -34,7 +28,9 @@ func Server() *schema.Resource {
 func createServer(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*config.CombinedConfig)
 
-	delay := time.Second * time.Duration((rand.Intn(maxSleep-minSleep+1) + minSleep))
+	delay := time.Duration(client.CreatedServersCount.Value()*10) * time.Second
+
+	client.CreatedServersCount.Inc()
 
 	client.Logger.With("delay", delay).Info("sleeping to avoid concurrency issues")
 


### PR DESCRIPTION
Previously delay was unpredictable when creating a server, this PR changes that so that there is 10sec delay in between.