### PR TITLE
feat: add logic to check server is actually up

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	Token            string
 	APIEndpoint      string
 	TerraformVersion string
+	ServerUpPort     int
 }
 
 type Counter struct {
@@ -39,6 +40,7 @@ type CombinedConfig struct {
 	api.ClientInterface
 	Logger              *slog.Logger
 	CreatedServersCount Counter
+	ServerUpPort        int
 }
 
 func NewCombinedConfig(config *Config, client api.ClientInterface) *CombinedConfig {
@@ -46,6 +48,7 @@ func NewCombinedConfig(config *Config, client api.ClientInterface) *CombinedConf
 		client,
 		slog.New(slog.NewTextHandler(os.Stdout, nil)),
 		Counter{},
+		config.ServerUpPort,
 	}
 }
 
@@ -66,5 +69,6 @@ func (c *Config) Client() (*CombinedConfig, diag.Diagnostics) {
 		webdockClient,
 		slog.New(slog.NewTextHandler(os.Stdout, nil)),
 		Counter{},
+		c.ServerUpPort,
 	}, nil
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,3 +22,4 @@ description: |-
 ### Optional
 
 - `api_endpoint` (String) The URL to use for the Webdock API.
+- `server_up_port` (Int) The port to be used when checking the server is actually up and ready to receive connections. by default 22.

--- a/webdock/datasource/images_test.go
+++ b/webdock/datasource/images_test.go
@@ -51,7 +51,9 @@ func TestDataSourceWebdockImages(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			test.mock()
 
-			diags := datasource.Images().ReadContext(ctx, test.rd, config.NewCombinedConfig(nil, client))
+			diags := datasource.Images().ReadContext(ctx, test.rd, config.NewCombinedConfig(&config.Config{
+				ServerUpPort: 2200,
+			}, client))
 
 			assert.Equal(t, test.diags, diags)
 		})

--- a/webdock/datasource/locations_test.go
+++ b/webdock/datasource/locations_test.go
@@ -53,7 +53,9 @@ func TestDataSourceWebdockLocationsRead(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			test.mock()
 
-			diags := datasource.Locations().ReadContext(ctx, test.rd, config.NewCombinedConfig(nil, client))
+			diags := datasource.Locations().ReadContext(ctx, test.rd, config.NewCombinedConfig(&config.Config{
+				ServerUpPort: 2200,
+			}, client))
 
 			assert.Equal(t, test.diags, diags)
 		})

--- a/webdock/datasource/profiles_test.go
+++ b/webdock/datasource/profiles_test.go
@@ -60,7 +60,9 @@ func TestDataSourceWebdockProfilesRead(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			test.mock()
 
-			diags := datasource.Profiles().ReadContext(ctx, test.rd, config.NewCombinedConfig(nil, client))
+			diags := datasource.Profiles().ReadContext(ctx, test.rd, config.NewCombinedConfig(&config.Config{
+				ServerUpPort: 2200,
+			}, client))
 
 			assert.Equal(t, test.diags, diags)
 		})

--- a/webdock/datasource/public_keys_test.go
+++ b/webdock/datasource/public_keys_test.go
@@ -53,7 +53,9 @@ func TestDataSourceWebdockPublicKeysRead(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			test.mock()
 
-			diags := datasource.PublicKeys().ReadContext(ctx, test.rd, config.NewCombinedConfig(nil, client))
+			diags := datasource.PublicKeys().ReadContext(ctx, test.rd, config.NewCombinedConfig(&config.Config{
+				ServerUpPort: 2200,
+			}, client))
 
 			assert.Equal(t, test.diags, diags)
 		})

--- a/webdock/datasource/servers_test.go
+++ b/webdock/datasource/servers_test.go
@@ -63,7 +63,9 @@ func TestDataSourceWebdockServersRead(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			test.mock()
 
-			diags := datasource.Servers().ReadContext(ctx, test.rd, config.NewCombinedConfig(nil, client))
+			diags := datasource.Servers().ReadContext(ctx, test.rd, config.NewCombinedConfig(&config.Config{
+				ServerUpPort: 2200,
+			}, client))
 
 			assert.Equal(t, test.diags, diags)
 		})

--- a/webdock/datasource/shell_users_test.go
+++ b/webdock/datasource/shell_users_test.go
@@ -56,7 +56,9 @@ func TestDataSourceWebdockShellUsersRead(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			test.mock()
 
-			diags := datasource.ShellUsers().ReadContext(ctx, test.rd, config.NewCombinedConfig(nil, client))
+			diags := datasource.ShellUsers().ReadContext(ctx, test.rd, config.NewCombinedConfig(&config.Config{
+				ServerUpPort: 2200,
+			}, client))
 
 			assert.Equal(t, test.diags, diags)
 		})

--- a/webdock/provider.go
+++ b/webdock/provider.go
@@ -25,6 +25,12 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("WEBDOCK_API_URL", "https://api.webdock.io"),
 				Description: "The URL to use for the Webdock API.",
 			},
+			"server_up_port": {
+				Type:        schema.TypeInt,
+				Required:    false,
+				DefaultFunc: schema.EnvDefaultFunc("WEBDOCK_SERVER_UP_PORT", 22),
+				Description: "The port to use when checking if the server is actually reachable.",
+			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"webdock_servers":     datasource.Servers(),
@@ -59,6 +65,7 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 	config := config.Config{
 		Token:            d.Get("token").(string),
 		APIEndpoint:      d.Get("api_endpoint").(string),
+		ServerUpPort:     d.Get("server_up_port").(int),
 		TerraformVersion: terraformVersion,
 	}
 

--- a/webdock/resource/public_key_test.go
+++ b/webdock/resource/public_key_test.go
@@ -23,21 +23,18 @@ func TestResourceWebdockPublicKeyCreate(t *testing.T) {
 	mockErr := errors.New("mock error")
 	tests := map[string]struct {
 		rd    *schema.ResourceData
-		meta  interface{}
 		diags diag.Diagnostics
 		mock  func()
 	}{
 		"when create public key fails": {
 			rd:    resource.PublicKey().Data(&terraform.InstanceState{}),
-			meta:  config.NewCombinedConfig(nil, client),
 			diags: diag.FromErr(mockErr),
 			mock: func() {
 				client.On("CreatePublicKey", ctx, mock.Anything).Once().Return(nil, mockErr)
 			},
 		},
 		"success": {
-			rd:   resource.PublicKey().Data(&terraform.InstanceState{}),
-			meta: config.NewCombinedConfig(nil, client),
+			rd: resource.PublicKey().Data(&terraform.InstanceState{}),
 			mock: func() {
 				client.On("CreatePublicKey", ctx, mock.Anything).Once().Return(&api.PublicKey{
 					Id:      json.Number("1"),
@@ -53,7 +50,9 @@ func TestResourceWebdockPublicKeyCreate(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			test.mock()
 
-			diags := resource.PublicKey().CreateContext(ctx, test.rd, test.meta)
+			diags := resource.PublicKey().CreateContext(ctx, test.rd, config.NewCombinedConfig(&config.Config{
+				ServerUpPort: 2200,
+			}, client))
 
 			assert.Equal(t, test.diags, diags)
 		})
@@ -66,13 +65,11 @@ func TestResourceWebdockPublicKeyDelete(t *testing.T) {
 	mockErr := errors.New("mock error")
 	tests := map[string]struct {
 		rd    *schema.ResourceData
-		meta  interface{}
 		diags diag.Diagnostics
 		mock  func()
 	}{
 		"when converting public key id to int64 fails": {
 			rd:    resource.PublicKey().Data(&terraform.InstanceState{}),
-			meta:  config.NewCombinedConfig(nil, client),
 			diags: diag.Errorf("error converting public key id to int64: strconv.ParseInt: parsing \"\": invalid syntax"),
 			mock:  func() {},
 		},
@@ -80,7 +77,6 @@ func TestResourceWebdockPublicKeyDelete(t *testing.T) {
 			rd: resource.PublicKey().Data(&terraform.InstanceState{
 				ID: "1",
 			}),
-			meta:  config.NewCombinedConfig(nil, client),
 			diags: diag.FromErr(mockErr),
 			mock: func() {
 				client.On("DeletePublicKey", ctx, mock.Anything).Once().Return(mockErr)
@@ -90,7 +86,6 @@ func TestResourceWebdockPublicKeyDelete(t *testing.T) {
 			rd: resource.PublicKey().Data(&terraform.InstanceState{
 				ID: "1",
 			}),
-			meta: config.NewCombinedConfig(nil, client),
 			mock: func() {
 				client.On("DeletePublicKey", ctx, mock.Anything).Once().Return(nil)
 			},
@@ -101,7 +96,9 @@ func TestResourceWebdockPublicKeyDelete(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			test.mock()
 
-			diags := resource.PublicKey().DeleteContext(ctx, test.rd, test.meta)
+			diags := resource.PublicKey().DeleteContext(ctx, test.rd, config.NewCombinedConfig(&config.Config{
+				ServerUpPort: 2200,
+			}, client))
 
 			assert.Equal(t, test.diags, diags)
 		})
@@ -114,13 +111,11 @@ func TestResourceWebdockPublicKeyRead(t *testing.T) {
 	mockErr := errors.New("mock error")
 	tests := map[string]struct {
 		rd    *schema.ResourceData
-		meta  interface{}
 		diags diag.Diagnostics
 		mock  func()
 	}{
 		"when get public keys fails": {
 			rd:    resource.PublicKey().Data(&terraform.InstanceState{}),
-			meta:  config.NewCombinedConfig(nil, client),
 			diags: diag.Errorf("error getting public key: %v", mockErr),
 			mock: func() {
 				client.On("GetPublicKeys", ctx).Once().Return(nil, mockErr)
@@ -130,7 +125,6 @@ func TestResourceWebdockPublicKeyRead(t *testing.T) {
 			rd: resource.PublicKey().Data(&terraform.InstanceState{
 				ID: "3",
 			}),
-			meta:  config.NewCombinedConfig(nil, client),
 			diags: diag.Errorf("error getting public key: not found"),
 			mock: func() {
 				client.On("GetPublicKeys", ctx).Once().Return(api.PublicKeys{
@@ -153,7 +147,6 @@ func TestResourceWebdockPublicKeyRead(t *testing.T) {
 			rd: resource.PublicKey().Data(&terraform.InstanceState{
 				ID: "3",
 			}),
-			meta:  config.NewCombinedConfig(nil, client),
 			diags: diag.Errorf("error getting public key: not found"),
 			mock: func() {
 				client.On("GetPublicKeys", ctx).Once().Return(nil, nil)
@@ -163,7 +156,6 @@ func TestResourceWebdockPublicKeyRead(t *testing.T) {
 			rd: resource.PublicKey().Data(&terraform.InstanceState{
 				ID: "2",
 			}),
-			meta: config.NewCombinedConfig(nil, client),
 			mock: func() {
 				client.On("GetPublicKeys", ctx).Once().Return(api.PublicKeys{
 					{
@@ -187,7 +179,9 @@ func TestResourceWebdockPublicKeyRead(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			test.mock()
 
-			diags := resource.PublicKey().ReadContext(ctx, test.rd, test.meta)
+			diags := resource.PublicKey().ReadContext(ctx, test.rd, config.NewCombinedConfig(&config.Config{
+				ServerUpPort: 2200,
+			}, client))
 
 			assert.Equal(t, test.diags, diags)
 		})

--- a/webdock/resource/server.go
+++ b/webdock/resource/server.go
@@ -77,7 +77,7 @@ createServer:
 	d.SetId(server.Slug)
 
 	if server.CallbackID != "" {
-		err = utils.WaitForAction(ctx, client, server.CallbackID)
+		err = utils.WaitForServerToBeUP(ctx, client, server.CallbackID, server.Ipv4, client.ServerUpPort)
 		if err != nil {
 			return diag.Errorf("server (%s) create event (%s) errored: %v", d.Id(), server.CallbackID, err)
 		}

--- a/webdock/resource/server_test.go
+++ b/webdock/resource/server_test.go
@@ -3,6 +3,7 @@ package resource_test
 import (
 	"context"
 	"errors"
+	"net"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -10,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/zolamk/terraform-provider-webdock/api"
 	"github.com/zolamk/terraform-provider-webdock/config"
 	"github.com/zolamk/terraform-provider-webdock/test/mocks"
@@ -20,15 +22,17 @@ func TestResourceWebdockServerCreate(t *testing.T) {
 	ctx := context.Background()
 	client := mocks.NewClientInterface(t)
 	mockErr := errors.New("mock error")
+	l, err := net.Listen("tcp", "127.0.0.1:2200")
+	require.Nil(t, err)
+	defer l.Close()
+
 	tests := map[string]struct {
 		rd    *schema.ResourceData
-		meta  interface{}
 		diags diag.Diagnostics
 		mock  func()
 	}{
 		"when create server fails": {
 			rd:    resource.Server().Data(&terraform.InstanceState{}),
-			meta:  config.NewCombinedConfig(nil, client),
 			diags: diag.FromErr(mockErr),
 			mock: func() {
 				client.On("CreateServer", ctx, mock.Anything).Once().Return(nil, mockErr)
@@ -36,7 +40,6 @@ func TestResourceWebdockServerCreate(t *testing.T) {
 		},
 		"when create server fails with too many server error": {
 			rd:    resource.Server().Data(&terraform.InstanceState{}),
-			meta:  config.NewCombinedConfig(nil, client),
 			diags: nil,
 			mock: func() {
 				client.On("CreateServer", ctx, mock.Anything).Twice().Return(nil, &api.APIError{
@@ -50,7 +53,7 @@ func TestResourceWebdockServerCreate(t *testing.T) {
 					Aliases:                []string{"test"},
 					Date:                   "2022-12-22T03:54:56+03:00",
 					Image:                  "test",
-					Ipv4:                   "83.69.106.70",
+					Ipv4:                   "127.0.0.1",
 					Ipv6:                   "8b34:f82b:999a:1ab5:0cad:f252:af94:bf80",
 					Location:               "test",
 					Name:                   "test",
@@ -72,7 +75,6 @@ func TestResourceWebdockServerCreate(t *testing.T) {
 		},
 		"when wait for action fails": {
 			rd:    resource.Server().Data(&terraform.InstanceState{}),
-			meta:  config.NewCombinedConfig(nil, client),
 			diags: diag.Errorf("server (test) create event (callback) errored: %v", mockErr),
 			mock: func() {
 				client.On("CreateServer", ctx, mock.Anything).Once().Return(&api.Server{
@@ -81,7 +83,7 @@ func TestResourceWebdockServerCreate(t *testing.T) {
 					Aliases:                []string{"test"},
 					Date:                   "2022-12-22T03:54:56+03:00",
 					Image:                  "test",
-					Ipv4:                   "83.69.106.70",
+					Ipv4:                   "127.0.0.1",
 					Ipv6:                   "8b34:f82b:999a:1ab5:0cad:f252:af94:bf80",
 					Location:               "test",
 					Name:                   "test",
@@ -99,7 +101,6 @@ func TestResourceWebdockServerCreate(t *testing.T) {
 		},
 		"when create event can't be found": {
 			rd:    resource.Server().Data(&terraform.InstanceState{}),
-			meta:  config.NewCombinedConfig(nil, client),
 			diags: diag.Errorf("unable to find server (test) create event"),
 			mock: func() {
 				client.On("CreateServer", ctx, mock.Anything).Once().Return(&api.Server{
@@ -108,7 +109,7 @@ func TestResourceWebdockServerCreate(t *testing.T) {
 					Aliases:                []string{"test"},
 					Date:                   "2022-12-22T03:54:56+03:00",
 					Image:                  "test",
-					Ipv4:                   "83.69.106.70",
+					Ipv4:                   "127.0.0.1",
 					Ipv6:                   "8b34:f82b:999a:1ab5:0cad:f252:af94:bf80",
 					Location:               "test",
 					Name:                   "test",
@@ -122,8 +123,7 @@ func TestResourceWebdockServerCreate(t *testing.T) {
 			},
 		},
 		"success": {
-			rd:   resource.Server().Data(&terraform.InstanceState{}),
-			meta: config.NewCombinedConfig(nil, client),
+			rd: resource.Server().Data(&terraform.InstanceState{}),
 			mock: func() {
 				client.On("CreateServer", ctx, mock.Anything).Once().Return(&api.Server{
 					SSHPasswordAuthEnabled: true,
@@ -131,7 +131,7 @@ func TestResourceWebdockServerCreate(t *testing.T) {
 					Aliases:                []string{"test"},
 					Date:                   "2022-12-22T03:54:56+03:00",
 					Image:                  "test",
-					Ipv4:                   "83.69.106.70",
+					Ipv4:                   "127.0.0.1",
 					Ipv6:                   "8b34:f82b:999a:1ab5:0cad:f252:af94:bf80",
 					Location:               "test",
 					Name:                   "test",
@@ -157,7 +157,9 @@ func TestResourceWebdockServerCreate(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			test.mock()
 
-			diags := resource.Server().CreateContext(ctx, test.rd, test.meta)
+			diags := resource.Server().CreateContext(ctx, test.rd, config.NewCombinedConfig(&config.Config{
+				ServerUpPort: 2200,
+			}, client))
 
 			assert.Equal(t, test.diags, diags)
 		})
@@ -170,21 +172,18 @@ func TestResourceWebdockServerRead(t *testing.T) {
 	mockErr := errors.New("mock error")
 	tests := map[string]struct {
 		rd    *schema.ResourceData
-		meta  interface{}
 		diags diag.Diagnostics
 		mock  func()
 	}{
 		"when get server by slug fails": {
 			rd:    resource.Server().Data(&terraform.InstanceState{}),
-			meta:  config.NewCombinedConfig(nil, client),
 			diags: diag.Errorf("error getting server: %v", mockErr),
 			mock: func() {
 				client.On("GetServerBySlug", ctx, mock.Anything).Once().Return(nil, mockErr)
 			},
 		},
 		"success": {
-			rd:   resource.Server().Data(&terraform.InstanceState{}),
-			meta: config.NewCombinedConfig(nil, client),
+			rd: resource.Server().Data(&terraform.InstanceState{}),
 			mock: func() {
 				client.On("GetServerBySlug", ctx, mock.Anything).Once().Return(&api.Server{
 					SSHPasswordAuthEnabled: true,
@@ -212,7 +211,9 @@ func TestResourceWebdockServerRead(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			test.mock()
 
-			diags := resource.Server().ReadContext(ctx, test.rd, test.meta)
+			diags := resource.Server().ReadContext(ctx, test.rd, config.NewCombinedConfig(&config.Config{
+				ServerUpPort: 2200,
+			}, client))
 
 			assert.Equal(t, test.diags, diags)
 		})

--- a/webdock/utils/wait_for_action.go
+++ b/webdock/utils/wait_for_action.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -29,6 +31,52 @@ func WaitForAction(ctx context.Context, client api.ClientInterface, callbackID s
 			}
 
 			event := (events)[0]
+
+			return event, event.Status, nil
+		}
+	)
+	_, err := (&resource.StateChangeConf{
+		Pending:    []string{pending, working},
+		Refresh:    refreshfn,
+		Target:     []string{target},
+		Delay:      10 * time.Second,
+		Timeout:    10 * time.Minute,
+		MinTimeout: 3 * time.Second,
+	}).WaitForStateContext(ctx)
+
+	return err
+}
+
+// WaitForServerToBeUp makes sure besides of getting finished status that the server is actually reachable on port 22
+func WaitForServerToBeUP(ctx context.Context, client api.ClientInterface, callbackID string, ip string, port int) error {
+	var (
+		pending   = "waiting"
+		working   = "working"
+		target    = "finished"
+		refreshfn = func() (result interface{}, state string, err error) {
+			opts := api.GetEventsParams{
+				CallbackId: callbackID,
+			}
+
+			events, err := client.GetEvents(ctx, opts)
+			if err != nil {
+				return nil, "", err
+			}
+
+			if len(events) == 0 {
+				return nil, "", errors.New("error getting event state: response body empty")
+			}
+
+			event := (events)[0]
+
+			if event.Status == target {
+				conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", ip, port))
+				if err != nil {
+					return event, working, nil
+				}
+
+				defer conn.Close()
+			}
 
 			return event, event.Status, nil
 		}


### PR DESCRIPTION
Webdock can take some time for the network to be up after the get events api has said provisioning is finished, this PR adds logic to check the network is up before saying server creation is finished.